### PR TITLE
Inputs should be released when hidraw controller disconnects

### DIFF
--- a/ds4drv/__main__.py
+++ b/ds4drv/__main__.py
@@ -105,6 +105,10 @@ class DS4Controller(object):
         self.logger.info("Disconnected")
         self.fire_event("device-cleanup")
         self.loop.remove_watcher(self.device.report_fd)
+
+        for action in self.actions:
+            action.handle_report(self.device.empty_report())
+
         self.device.close()
         self.device = None
 

--- a/ds4drv/actions.py
+++ b/ds4drv/actions.py
@@ -170,7 +170,7 @@ class ReportActionInput(ReportAction):
         # allow for at least one fresh report to be received inbetween
         self.add_timer(0.005, self.emit_mouse)
 
-    def cleanup(self):
+    def disable(self):
         self.remove_timer(self.emit_mouse)
 
     def load_options(self, options):

--- a/ds4drv/device.py
+++ b/ds4drv/device.py
@@ -203,6 +203,54 @@ class DS4Device(object):
     def read_report(self):
         pass
 
+    def empty_report(self):
+        return DS4Report(
+            # Left analog stick
+            128, 128,
+
+            # Right analog stick
+            128, 128,
+
+            # L2 and R2 analog
+            0, 0,
+
+            # DPad up, down, left, right
+            False, False, False, False,
+
+            # Buttons cross, circle, square, triangle
+            False, False, False, False,
+
+            # L1, L2 and L3 buttons
+            False, False, False,
+
+            # R1, R2,and R3 buttons
+            False, False, False,
+
+            # Share and option buttons
+            False, False,
+
+            # Trackpad and PS buttons
+            False, False,
+
+            # Acceleration
+            0, 0, 0,
+
+            # Orientation
+            0, 0, 0,
+
+            # Trackpad touch 1: id, active, x, y
+            0, False, 0, 0,
+
+            # Trackpad touch 2: id, active, x, y
+            0, False, 0, 0,
+
+            # Timestamp and battery
+            0, 8,
+
+            # External inputs (usb, audio, mic)
+            False, False, False
+        )
+
     def write_report(self, report_id, data):
         pass
 


### PR DESCRIPTION
If a hidraw controller is disconnected while some buttons are pressed, the buttons will stay down. This might not matter so much with joystick input, but it is really annoying with mouse or keyboard bindings. Analog stick mouse will also keep moving even after the controller is disconnected.

All inputs should be released when the controller is disconnected, even if we don't want to remove the uinput devices.
