### PR TITLE
Add mousewheel emulation and support for trailing comments in ds4drv.conf.

### DIFF
--- a/ds4drv.conf
+++ b/ds4drv.conf
@@ -106,6 +106,10 @@ REL_Y = right_analog_y
 BTN_LEFT = button_r2
 BTN_RIGHT = button_l2
 
+# Emulate mouse wheel on r1 and l1
+REL_WHEELUP = button_l1
+REL_WHEELDOWN = button_r1
+
 # Mouse settings
 #mouse_sensitivity = 0.6
 #mouse_deadzone = 5


### PR DESCRIPTION
uinput.py:  Added support for emulating a mousewheel (up or down).
uinput.py:  Added support for trailing comments in ds4drv.conf files.
ds4drv.conf:  Added scroll wheel emulation example.
