### PR TITLE
Make ds4drv compatible with python-evdev 0.6.0

### DIFF
--- a/ds4drv/uinput.py
+++ b/ds4drv/uinput.py
@@ -16,7 +16,7 @@ absInfoUsesValue = hasattr(util, "resolve_ecodes_dict")
 BUTTON_MODIFIERS = ("+", "-")
 
 DEFAULT_A2D_DEADZONE = 50
-DEFAULT_AXIS_OPTIONS = (0, 255, 0, 5)
+DEFAULT_AXIS_OPTIONS = (0, 0, 255, 0, 5)
 DEFAULT_MOUSE_SENSITIVTY = 0.6
 DEFAULT_MOUSE_DEADZONE = 5
 DEFAULT_SCROLL_REPEAT_DELAY = .250 # Seconds to wait before continual scrolling

--- a/ds4drv/uinput.py
+++ b/ds4drv/uinput.py
@@ -254,7 +254,7 @@ class UInputDevice(object):
         for name in layout.axes:
             params = layout.axes_options.get(name, DEFAULT_AXIS_OPTIONS)
             if not absInfoUsesValue:
-                params = (params[0],) + params[2:]
+                params = params[1:]
             events[ecodes.EV_ABS].append((name, params))
 
         for name in layout.hats:


### PR DESCRIPTION
As mentioned in issue #70, ds4drv does not currently work with python-evdev 0.6.0. The following changes allow ds4drv to work with python-evdev 0.6.0. I added a small check to try to keep the code compatible with python-evdev < 0.6.0 but there might be a better way to check for the presence of an older version of that package.