### PR TITLE
Use proper axis min and max when calculating initial axis value

### DIFF
--- a/ds4drv/uinput.py
+++ b/ds4drv/uinput.py
@@ -347,7 +347,7 @@ class UInputDevice(object):
         """Resets the device to a blank state."""
         for name in self.layout.axes:
             params = self.layout.axes_options.get(name, DEFAULT_AXIS_OPTIONS)
-            self.write_event(ecodes.EV_ABS, name, int(sum(params[:2]) / 2))
+            self.write_event(ecodes.EV_ABS, name, int(sum(params[1:3]) / 2))
 
         for name in self.layout.buttons:
             self.write_event(ecodes.EV_KEY, name, False)


### PR DESCRIPTION
This issue is related to issue #59. The UInputDevice.emit_reset method was not updated to take the value index for axis options into account. This small change makes sure that the proper min and max values for an axis are grabbed.