### PR TITLE
Added SIGINT handling

### DIFF
--- a/ds4drv/eventloop.py
+++ b/ds4drv/eventloop.py
@@ -47,6 +47,10 @@ class EventLoop(object):
     def __init__(self):
         self.stop()
 
+        # Timeout value well over the expected controller poll time, but
+        # short enough for ds4drv to shut down in a reasonable time.
+        self.epoll_timeout = 1
+
     def create_timer(self, interval, callback):
         """Creates a timer."""
 
@@ -95,7 +99,7 @@ class EventLoop(object):
         """Starts the loop."""
         self.running = True
         while self.running:
-            for fd, event in self.epoll.poll():
+            for fd, event in self.epoll.poll(self.epoll_timeout):
                 callback = self.callbacks.get(fd)
                 if callback:
                     callback()


### PR DESCRIPTION
Usually when exiting ds4drv with ^C I'd get a lot of traceback garbage. This gets rid of that. It also handles closing the controller threads more gracefully, since https://docs.python.org/2/library/threading.html suggests that daemon threads not closed properly might not release resources properly.

The main bit of trickery here is setting a timeout on epoll.poll. I went for 1 second because it's much higher than the expected time to wait for a controller poll, and short enough that a user won't really notice it. Without that, shutdown freezes until the poll naturally times out.