### PR TITLE
Bluetooth hidraw leds

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,9 +104,6 @@ suggested googling: *<distro name> bluetooth pairing*
 To use the DS4 via USB in this mode, simply connect your DS4 to your computer via
 a micro USB cable.
 
-**Note:** Unfortunately due to a kernel bug it is currently not possible to use
-any LED functionality when using bluetooth devices in this mode.
-
 
 Permissions
 ^^^^^^^^^^^

--- a/ds4drv/backends/hidraw.py
+++ b/ds4drv/backends/hidraw.py
@@ -63,16 +63,14 @@ class HidrawDS4Device(DS4Device):
         return fcntl.ioctl(self.fd, op, bytes(buf))
 
     def write_report(self, report_id, data):
-        if self.type == "bluetooth":
-            # TODO: Add a check for a kernel that supports writing
-            # output reports when such a kernel has been released.
-            return
-
         hid = bytearray((report_id,))
         self.fd.write(hid + data)
 
     def close(self):
         try:
+            # Reset LED to original hidraw pairing colour.
+            self.set_led(0, 0, 1)
+
             self.fd.close()
             self.input_device.ungrab()
         except IOError:


### PR DESCRIPTION
There was nothing stopping the LEDs from working with Bluetooth on hidraw, there was just a return statement in the hidraw bluetooth write_report method. The only problem I had was the LEDs didn't change back to a neutral colour on disconnecting.

Coupled with the other pull request I made for graceful thread closing with device disconnection, this resets the LEDs to a default colour on closing ds4drv.