### PR TITLE
Add controller "splash" on connection

### DIFF
--- a/ds4drv/actions/__init__.py
+++ b/ds4drv/actions/__init__.py
@@ -7,3 +7,4 @@ from . import dump
 from . import input
 from . import led
 from . import status
+from . import splash

--- a/ds4drv/actions/splash.py
+++ b/ds4drv/actions/splash.py
@@ -10,11 +10,14 @@ Action.add_option("--no-splash", action="store_true",
 class ActionSplash(Action):
     """Rumble controller and flash LEDs on connection."""
 
-    def load_options(self, options):
-        if not self.controller.device:
-            return
+    def __init__(self, *args, **kwargs):
+        super(ActionSplash, self).__init__(*args, **kwargs)
 
-        if options.no_splash == True:
+        self.led = (0, 0, 1)
+        self.no_splash = False
+
+    def setup(self, device):
+        if self.no_splash == True:
             return
 
         def interpolate_leds(l1, l2, n):
@@ -39,7 +42,7 @@ class ActionSplash(Action):
 
         self.controller.device.rumble(small_rumble, big_rumble)
         for led in interpolate_leds(
-            (0, 0, 0), (255, 255, 0), splash_frame_counts[0]
+            self.led, (255, 255, 0), splash_frame_counts[0]
         ):
             self.controller.device.set_led(*tuple(map(int, led)))
             sleep(splash_frame_time)
@@ -60,9 +63,13 @@ class ActionSplash(Action):
 
         self.controller.device.rumble(0, 0)
         for led in interpolate_leds(
-            (0, 0, 0), options.led, splash_frame_counts[2]
+            (0, 0, 0), self.led, splash_frame_counts[2]
         ):
             self.controller.device.set_led(*tuple(map(int, led)))
             sleep(splash_frame_time)
 
-        self.controller.device.set_led(*(options.led))
+        self.controller.device.set_led(*(self.led))
+
+    def load_options(self, options):
+        self.led = options.led
+        self.no_splash = options.no_splash

--- a/ds4drv/actions/splash.py
+++ b/ds4drv/actions/splash.py
@@ -1,0 +1,68 @@
+from ..action import Action
+
+from time import sleep
+
+
+Action.add_option("--no-splash", action="store_true",
+                  help="Disable rumbling controller and flashing LEDs on connection.")
+
+
+class ActionSplash(Action):
+    """Rumble controller and flash LEDs on connection."""
+
+    def load_options(self, options):
+        if not self.controller.device:
+            return
+
+        if options.no_splash == True:
+            return
+
+        def interpolate_leds(l1, l2, n):
+            diff = (
+                (l2[0] - l1[0])/n,
+                (l2[1] - l1[1])/n,
+                (l2[2] - l1[2])/n
+            )
+            for i in range(n):
+                yield (
+                    l1[0] + diff[0]*i,
+                    l1[1] + diff[1]*i,
+                    l1[2] + diff[2]*i
+                )
+
+        splash_time = 1
+        splash_frame_counts = [10, 10, 10, 10]
+        splash_frame_time = splash_time/sum(splash_frame_counts)
+
+        big_rumble = 255
+        small_rumble = 255
+
+        self.controller.device.rumble(small_rumble, big_rumble)
+        for led in interpolate_leds(
+            (0, 0, 0), (255, 255, 0), splash_frame_counts[0]
+        ):
+            self.controller.device.set_led(*tuple(map(int, led)))
+            sleep(splash_frame_time)
+
+        self.controller.device.rumble(0, 0)
+        for led in interpolate_leds(
+            (255, 255, 0), (0, 255, 255), splash_frame_counts[1]
+        ):
+            self.controller.device.set_led(*tuple(map(int, led)))
+            sleep(splash_frame_time)
+
+        self.controller.device.rumble(small_rumble, big_rumble)
+        for led in interpolate_leds(
+            (0, 255, 255), (0, 0, 0), splash_frame_counts[2]
+        ):
+            self.controller.device.set_led(*tuple(map(int, led)))
+            sleep(splash_frame_time)
+
+        self.controller.device.rumble(0, 0)
+        for led in interpolate_leds(
+            (0, 0, 0), options.led, splash_frame_counts[2]
+        ):
+            self.controller.device.set_led(*tuple(map(int, led)))
+            sleep(splash_frame_time)
+
+        self.controller.device.set_led(*(options.led))

--- a/ds4drv/device.py
+++ b/ds4drv/device.py
@@ -81,16 +81,24 @@ class DS4Device(object):
         self._led_flash = (0, 0)
         self._led_flashing = False
 
+        self._small_rumble = 0
+        self._big_rumble = 0
+
         self.set_operational()
 
     def _control(self, **kwargs):
         self.control(led_red=self._led[0], led_green=self._led[1],
                      led_blue=self._led[2], flash_led1=self._led_flash[0],
-                     flash_led2=self._led_flash[1], **kwargs)
+                     flash_led2=self._led_flash[1],
+                     big_rumble = self._big_rumble,
+                     small_rumble = self._small_rumble,
+                     **kwargs)
 
     def rumble(self, small=0, big=0):
         """Sets the intensity of the rumble motors. Valid range is 0-255."""
-        self._control(small_rumble=small, big_rumble=big)
+        self._big_rumble = big
+        self._small_rumble = small
+        self._control()
 
     def set_led(self, red=0, green=0, blue=0):
         """Sets the LED color. Values are RGB between 0-255."""


### PR DESCRIPTION
This implements #89.

It's synchronous, so it freezes the controller for the 2 seconds it runs. This is to make sure the splash action and LED actions don't cancel each other out. This sort of makes the LED action obsolete, since it calls `device.set_led(*(options.led))` at the end.
