### PR TITLE
Add PS4 v2 controller id

### DIFF
--- a/udev/50-ds4drv.rules
+++ b/udev/50-ds4drv.rules
@@ -1,3 +1,5 @@
 KERNEL=="uinput", MODE="0666"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="054c", ATTRS{idProduct}=="05c4", MODE="0666"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", KERNELS=="0005:054C:05C4.*", MODE="0666"
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="054c", ATTRS{idProduct}=="09cc", MODE="0666"
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", KERNELS=="0005:054C:09CC.*", MODE="0666"


### PR DESCRIPTION
This adds the id for the ps4 controller (see https://github.com/torvalds/linux/blob/7ae123edd37a47e178eb9a6631fe4a7108262c10/drivers/hid/hid-ids.h) to the udev rules. This allows you to run ds4drv without sudo when you have a ps4 v2 controller (otherwise you get a permission denied error).