### PR TITLE
Add DS4 USB Wireless Adaptor hidraw name

### DIFF
--- a/ds4drv/backends/hidraw.py
+++ b/ds4drv/backends/hidraw.py
@@ -106,6 +106,7 @@ class HidrawUSBDS4Device(HidrawDS4Device):
 HID_DEVICES = {
     "Sony Interactive Entertainment Wireless Controller": HidrawUSBDS4Device,
     "Sony Computer Entertainment Wireless Controller": HidrawUSBDS4Device,
+    u"Sony Interactive Entertainment DUALSHOCK\xae4 USB Wireless Adaptor": HidrawUSBDS4Device,
     "Wireless Controller": HidrawBluetoothDS4Device,
 }
 


### PR DESCRIPTION
The DS4 USB wireless adapter behaves the same way as a USB DS4, it is seen by linux as a HID device. This PR adds the hidraw name to be able to use ds4drv with a DS4 USB wireless adapter.