### PR TITLE
Use demandimport optimistically, makes running ds4drv instant.

### DIFF
--- a/ds4drv/__main__.py
+++ b/ds4drv/__main__.py
@@ -1,3 +1,9 @@
+try:
+    import demandimport
+    demandimport.enable()
+except ImportError:
+    pass
+
 import sys
 import signal
 


### PR DESCRIPTION
This causes imports to be lazily loaded. It's not required like this, so it only uses it if it's there already. This does however make execution extremely fast. :)