### PR TITLE
[Ubuntu 16.04] Replace the argument of ExecStart

### DIFF
--- a/systemd/ds4drv.service
+++ b/systemd/ds4drv.service
@@ -4,7 +4,7 @@ Requires=bluetooth.service
 After=bluetooth.service
 
 [Service]
-ExecStart=/usr/bin/ds4drv
+ExecStart=/usr/local/bin/ds4drv
 Restart=on-abort
 
 [Install]


### PR DESCRIPTION
Replaced the argument of ExecStart with /usr/local/bin/ds4drv returned from which ds4drv command.