### PR TITLE
Fix imu report (linear acceleration and angular velocity)

### DIFF
--- a/ds4drv/device.py
+++ b/ds4drv/device.py
@@ -41,12 +41,12 @@ class DS4Report(object):
                  "button_options",
                  "button_trackpad",
                  "button_ps",
-                 "motion_y",
-                 "motion_x",
-                 "motion_z",
                  "orientation_roll",
-                 "orientation_yaw",
                  "orientation_pitch",
+                 "orientation_yaw",
+                 "motion_x",
+                 "motion_y",
+                 "motion_z",
                  "trackpad_touch0_id",
                  "trackpad_touch0_active",
                  "trackpad_touch0_x",
@@ -181,13 +181,13 @@ class DS4Device(object):
             # Trackpad and PS buttons
             (buf[7] & 2) != 0, (buf[7] & 1) != 0,
 
-            # Acceleration
+            # Orientation
             S16LE.unpack_from(buf, 13)[0],
             S16LE.unpack_from(buf, 15)[0],
             S16LE.unpack_from(buf, 17)[0],
 
-            # Orientation
-            -(S16LE.unpack_from(buf, 19)[0]),
+            # Acceleration
+            S16LE.unpack_from(buf, 19)[0],
             S16LE.unpack_from(buf, 21)[0],
             S16LE.unpack_from(buf, 23)[0],
 

--- a/ds4drv/device.py
+++ b/ds4drv/device.py
@@ -41,12 +41,12 @@ class DS4Report(object):
                  "button_options",
                  "button_trackpad",
                  "button_ps",
-                 "orientation_roll",
-                 "orientation_pitch",
-                 "orientation_yaw",
-                 "motion_x",
-                 "motion_y",
-                 "motion_z",
+                 "ang_vel_x",
+                 "ang_vel_y",
+                 "ang_vel_z",
+                 "lin_acc_x",
+                 "lin_acc_y",
+                 "lin_acc_z",
                  "trackpad_touch0_id",
                  "trackpad_touch0_active",
                  "trackpad_touch0_x",
@@ -181,12 +181,12 @@ class DS4Device(object):
             # Trackpad and PS buttons
             (buf[7] & 2) != 0, (buf[7] & 1) != 0,
 
-            # Orientation
+            # Angular velocity
             S16LE.unpack_from(buf, 13)[0],
             S16LE.unpack_from(buf, 15)[0],
             S16LE.unpack_from(buf, 17)[0],
 
-            # Acceleration
+            # Linear acceleration
             S16LE.unpack_from(buf, 19)[0],
             S16LE.unpack_from(buf, 21)[0],
             S16LE.unpack_from(buf, 23)[0],

--- a/ds4drv/uinput.py
+++ b/ds4drv/uinput.py
@@ -72,12 +72,12 @@ create_mapping(
         "ABS_RZ":       "right_analog_y",
         "ABS_RX":       "l2_analog",
         "ABS_RY":       "r2_analog",
-        "ABS_THROTTLE": "orientation_roll",
-        "ABS_RUDDER":   "orientation_pitch",
-        "ABS_WHEEL":    "orientation_yaw",
-        "ABS_DISTANCE": "motion_z",
-        "ABS_TILT_X":   "motion_x",
-        "ABS_TILT_Y":   "motion_y",
+        "ABS_THROTTLE": "ang_vel_x",
+        "ABS_RUDDER":   "ang_vel_y",
+        "ABS_WHEEL":    "ang_vel_z",
+        "ABS_DISTANCE": "lin_acc_z",
+        "ABS_TILT_X":   "lin_acc_x",
+        "ABS_TILT_Y":   "lin_acc_y",
     },
     # Axes options
     {


### PR DESCRIPTION
I've noticed that the linear acceleration and angular velocity reported from the device is incorrect. I looked into this problem and found that the order of fields were incorrect. With this PR the linear acceleration and angular velocity become consistent.

The following axis orientation is used (since I couldn't find any specific convention used in the code):

X: points to the right
Y: points up
Z: points towards the person holding the device

If needed I can post plots that I used to confirm that the fix is indeed consistent with the axis orientation above.

The following websites were references:
- https://gamedev.stackexchange.com/a/87178
- https://www.bosch-sensortec.com/bst/products/all_products/bmi055
- http://eleccelerator.com/wiki/index.php?title=DualShock_4#Report_Structure