### PR TITLE
add options to override virtual device name and vendor/product/version IDs

### DIFF
--- a/ds4drv/actions/input.py
+++ b/ds4drv/actions/input.py
@@ -23,6 +23,11 @@ ReportAction.add_option("--mapping", metavar="mapping",
                              "config file")
 ReportAction.add_option("--trackpad-mouse", action="store_true",
                         help="Makes the trackpad control the mouse")
+ReportAction.add_option("--vdev-name", metavar="name",
+                        help="Override the virtual device name")
+ReportAction.add_option("--vdev-ids", metavar="[vid]:[pid]:[vers]",
+                        help="Override the virtual device vendor, product "
+                             "and/or version IDs (in hex)")
 
 
 class ReportActionInput(ReportAction):
@@ -71,12 +76,23 @@ class ReportActionInput(ReportAction):
                 self.mouse.device.close()
                 self.mouse = None
 
+            vdev_ids = ((options.vdev_ids or "") + "::").split(":",3)
+            vendor = int(vdev_ids[0], 16) if vdev_ids[0] else None
+            product = int(vdev_ids[1], 16) if vdev_ids[1] else None
+            version = int(vdev_ids[2], 16) if vdev_ids[2] else None
+
             if self.joystick and self.joystick_layout != joystick_layout:
                 self.joystick.device.close()
-                joystick = create_uinput_device(joystick_layout)
+                joystick = create_uinput_device(joystick_layout,
+                                                options.vdev_name,
+                                                vendor, product,
+                                                version)
                 self.joystick = joystick
             elif not self.joystick:
-                joystick = create_uinput_device(joystick_layout)
+                joystick = create_uinput_device(joystick_layout,
+                                                options.vdev_name,
+                                                vendor, product,
+                                                version)
                 self.joystick = joystick
                 if joystick.device.device:
                     self.logger.info("Created devices {0} (joystick) "

--- a/ds4drv/uinput.py
+++ b/ds4drv/uinput.py
@@ -233,17 +233,17 @@ create_mapping(
 
 
 class UInputDevice(object):
-    def __init__(self, layout):
+    def __init__(self, layout, description=None, vendor=None, product=None, version=None):
         self.joystick_dev = None
         self.evdev_dev = None
         self.ignored_buttons = set()
-        self.create_device(layout)
+        self.create_device(layout, description, vendor, product, version)
 
         self._write_cache = {}
         self._scroll_details = {}
         self.emit_reset()
 
-    def create_device(self, layout):
+    def create_device(self, layout, description=None, vendor=None, product=None, version=None):
         """Creates a uinput device using the specified layout."""
         events = {ecodes.EV_ABS: [], ecodes.EV_KEY: [],
                   ecodes.EV_REL: []}
@@ -296,9 +296,14 @@ class UInputDevice(object):
                     events[ecodes.EV_REL].append(name)
                 self.mouse_rel[name] = 0.0
 
-        self.device = UInput(name=layout.name, events=events,
-                             bustype=layout.bustype, vendor=layout.vendor,
-                             product=layout.product, version=layout.version)
+        description = layout.name if description is None else description
+        vendor = layout.vendor if vendor is None else vendor
+        product = layout.product if product is None else product
+        version = layout.version if version is None else version
+
+        self.device = UInput(name=description, events=events,
+                             bustype=layout.bustype, vendor=vendor,
+                             product=product, version=version)
         self.layout = layout
 
     def write_event(self, etype, code, value):
@@ -435,14 +440,14 @@ class UInputDevice(object):
         self.device.syn()
 
 
-def create_uinput_device(mapping):
+def create_uinput_device(mapping, description=None, vendor=None, product=None, version=None):
     """Creates a uinput device."""
     if mapping not in _mappings:
         raise DeviceError("Unknown device mapping: {0}".format(mapping))
 
     try:
         mapping = _mappings[mapping]
-        device = UInputDevice(mapping)
+        device = UInputDevice(mapping, description, vendor, product, version)
     except UInputError as err:
         raise DeviceError(err)
 


### PR DESCRIPTION
Some games' built-in support for certain controllers seems not to work correctly when run via wine, but if the USB IDs of ds4drv's virtual uinput device are changed to something that does not emulate a real device (i.e. a real DS4 or XBox controller), then it works just fine as a "generic joystick."

Specifically, Elite Dangerous run via Steam/Proton has this problem. If ds4drv's virtual vid:pid match a real DS4 or Xbox controller, then the game cannot bind actions to certain controller functions (such as the touchpad click); conversely if ds4drv sets the vid:pid to 0:0, then the game thinks the controller is invalid and cannot save control bindings for it at all. But by "spoofing" the vid:pid (using i.e. 27dc:16c0), the controller works perfectly.