### PR TITLE
Replaced 'SafeConfigParser' with 'ConfigParser' to comply with python >3.12

### DIFF
--- a/ds4drv/config.py
+++ b/ds4drv/config.py
@@ -69,7 +69,7 @@ daemonopt.add_argument("--daemon-pid", default=DAEMON_PID_FILE, metavar="file",
 controllopt = parser.add_argument_group("controller options")
 
 
-class Config(configparser.SafeConfigParser):
+class Config(configparser.ConfigParser):
     def load(self, filename):
         self.read([filename])
 
@@ -96,7 +96,7 @@ class Config(configparser.SafeConfigParser):
             return {}
 
     def sections(self, prefix=None):
-        for section in configparser.SafeConfigParser.sections(self):
+        for section in configparser.ConfigParser.sections(self):
             match = re.match(r"{0}:(.+)".format(prefix), section)
             if match:
                 yield match.group(1), section


### PR DESCRIPTION
This is a simple fix that makes ds4drv work with python >= 3.12
It would make installation less of a hassle for newer machines. 
I'd be happy to look deeper into it if the change from "SafeConfigParser" to "ConfigParser" led to any security issue. 
